### PR TITLE
chore: final AGENTS.md unification and legacy cleanup

### DIFF
--- a/.agent/agents/security-reviewer/SYSTEM.md
+++ b/.agent/agents/security-reviewer/SYSTEM.md
@@ -49,6 +49,6 @@ Enforce the following security gates:
 - **NIST Computer Security Incident Handling Guide:** https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf
 
 ## 5. Operating Principles
-* **Context First**: Read `README.md` or `AGENT.md` to understand the security perimeter.
+* **Context First**: Read `README.md` or `AGENTS.md` to understand the security perimeter.
 * **Technical Tone**: Be blunt, exact, and paranoid. Omit fluff.
 * **Isolation**: You are self-contained. Do not rely on external shared assets.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 - [ ] **Java/Spring**: `mvn clean compile` and tests pass locally.
 - [ ] **Infrastructure**: `terraform validate` or `helm lint` passed.
 - [ ] **Security**: No secrets or credentials have been committed.
-- [ ] I have updated the `README.md` or `AGENT.md` if necessary.
+- [ ] I have updated the `README.md` or `AGENTS.md` if necessary.
 
 ## Related Issues
 <!-- Link any related issues using #issue_number (e.g. Closes #123) -->

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/conductor/tech-stack.md
+++ b/conductor/tech-stack.md
@@ -9,7 +9,7 @@
 | Bash / Shell | POSIX | CI scripts, provisioning helpers, bin/ utilities |
 | HCL | Terraform 1.7+ | Infrastructure as code for AWS, GCP, Azure |
 | YAML | ansible-core 2.15+ | Configuration management and provisioning |
-| Markdown | GitHub Flavored | Documentation, skill definitions, AGENT.md |
+| Markdown | GitHub Flavored | Documentation, skill definitions, AGENTS.md |
 | JSON | standard | Relationship graph, AST cache, API payloads |
 
 ## Frameworks & Build Tools


### PR DESCRIPTION
## Description
This Pull Request performs the final cleanup of the agentic manifest system, unifying the repository on the plural **`AGENTS.md`** and removing the legacy singular `AGENT.md` symlink.

### Key Changes:
1.  **Legacy Manifest Removal**: Deleted the `AGENT.md` symlink.
2.  **Reference Unification**:
    *   Updated the **`security-reviewer`** system prompt to point strictly to `AGENTS.md`.
    *   Updated the **Pull Request Template** checklist to use `AGENTS.md`.
    *   Updated the **`conductor/tech-stack.md`** documentation to reflect the plural naming convention.
3.  **Vercel Standard Maintenance**: Preserved the "Compressed Index" and "Retrieval-Led" directives established in the previous phase.

## Type of Change
- [x] Chore (non-breaking change which improves internal repository state)
- [x] Documentation update

## Checklist
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings (Lint/Compiler).
- [x] **Java/Spring**: `mvn clean compile` passed locally.
- [x] **Infrastructure**: `terraform validate` passed.
- [x] I have updated the `README.md` or `AGENTS.md` if necessary.

## Related Issues
Relates to #33
